### PR TITLE
#2 카카오맵 핸들링 구현 및 justand 설치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "programmers_2nd",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.6.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -26,7 +27,8 @@
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.13",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.0-rc.2"
       },
       "devDependencies": {
         "@types/axios": "^0.14.0",
@@ -2419,6 +2421,14 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz",
+      "integrity": "sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18510,6 +18520,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.0-rc.2.tgz",
+      "integrity": "sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.6.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -21,7 +22,8 @@
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.13",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^5.0.0-rc.2"
   },
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx",

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -27,7 +27,10 @@
     <title>React App</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%&libraries=services"
+    ></script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/components/main/list.tsx
+++ b/src/components/main/list.tsx
@@ -2,16 +2,31 @@ import React from "react";
 import { ParkingData } from "../../interfaces/parkingData";
 
 interface ListProps {
-  parkingData: ParkingData[]; // 주차장 데이터 배열
+  parkingData: ParkingData[];
+  onItemClick: (parking: ParkingData) => void;
 }
 
-export default function List({ parkingData }: ListProps) {
+export default function List({ parkingData, onItemClick }: ListProps) {
+  const handleKeyDown = (
+    parking: ParkingData,
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    // Enter 키 또는 Space 키가 눌렸을 때 클릭 핸들러 호출 (베리어 프리)
+    if (event.key === "Enter" || event.key === " ") {
+      onItemClick(parking);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-5 pt-6 border-t border-gray-300 border-t-1">
       {parkingData.map(parking => (
         <div
           key={parking.LAT}
-          className="flex flex-col gap-3 py-2 border-b border-gray-200"
+          className="flex flex-col gap-3 py-2 border-b border-gray-200 cursor-pointer "
+          onClick={() => onItemClick(parking)}
+          onKeyDown={event => handleKeyDown(parking, event)} // 키보드 이벤트 추가(장애가 있는 사용자. 베리어 프리)
+          tabIndex={0} // 요소를 포커스 가능하게 설정
+          role="button"
         >
           <h2 className="text-3xl font-light text-secondary">
             {parking.PKLT_NM}

--- a/src/components/main/map.tsx
+++ b/src/components/main/map.tsx
@@ -1,5 +1,28 @@
 import React from "react";
+import useMap from "../../hooks/useMap";
 
 export default function Map() {
-  return <div className="h-full border border-blue-400">map</div>;
+  const { buttons } = useMap();
+
+  return (
+    <div>
+      <div
+        id="map"
+        className="relative h-full"
+        style={{ width: "100%", height: "100vh" }}
+      >
+        <div className="absolute flex flex-col items-center space-y-4 bottom-20 right-12">
+          {buttons.map(button => (
+            <button
+              onClick={button.onClick}
+              type="button"
+              className={button.className}
+              aria-label={button["aria-label"]}
+              style={{ zIndex: 10, width: "60px", height: "60px" }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/main/sidebar.tsx
+++ b/src/components/main/sidebar.tsx
@@ -4,8 +4,18 @@ import Input from "../common/input";
 import List from "./list";
 import LoadingSpinner from "../common/loadingSpinner";
 import useSidebar from "../../hooks/useSidebar";
+import { ParkingData } from "../../interfaces/parkingData";
 
-export default function Sidebar() {
+interface SidebarProps {
+  onParkingSelect: (parking: ParkingData) => void;
+  isApiCalled: boolean;
+  setIsApiCalled: (value: boolean) => void;
+}
+export default function Sidebar({
+  onParkingSelect,
+  isApiCalled,
+  setIsApiCalled,
+}: SidebarProps) {
   const {
     region,
     handleInputChange,
@@ -14,22 +24,32 @@ export default function Sidebar() {
     isLoading,
     scrollableRef,
   } = useSidebar();
+
+  const handleInput = (value: string) => {
+    handleInputChange(value);
+    setIsApiCalled(true);
+  };
+
   return (
-    <div className="relative h-full">
+    <div className="relative px-6 overflow-y-auto">
       <Header />
-      <Input onInputChange={handleInputChange} value={inputValue} />
-      <h1 className="py-8 text-4xl">
-        {region
-          ? `${region} 근처 주차장이에요.`
-          : "주차장 정보를 찾고 있습니다..."}
-      </h1>
-      <div
-        className="flex-grow max-h-[calc(100vh-200px)] overflow-y-auto"
-        ref={scrollableRef}
-      >
-        <List parkingData={parkingData} />
-        {isLoading && <LoadingSpinner type={6} />}
-      </div>
+      <Input onInputChange={handleInput} value={inputValue} />
+      {isApiCalled ? (
+        <>
+          <h1 className="py-8 text-4xl">
+            {region
+              ? `${region} 근처 주차장이에요.`
+              : "주차장 정보를 찾고 있습니다..."}
+          </h1>
+          <div
+            className="flex-grow max-h-[calc(100vh-200px)] overflow-y-auto"
+            ref={scrollableRef}
+          >
+            <List parkingData={parkingData} onItemClick={onParkingSelect} />
+            {isLoading && <LoadingSpinner type={6} />}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/components/main/sidebar.tsx
+++ b/src/components/main/sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Header from "../layout/header";
 import Input from "../common/input";
 import List from "./list";
@@ -17,18 +17,22 @@ export default function Sidebar({
   setIsApiCalled,
 }: SidebarProps) {
   const {
-    region,
     handleInputChange,
     inputValue,
     parkingData,
     isLoading,
     scrollableRef,
+    currentDistrict,
   } = useSidebar();
 
   const handleInput = (value: string) => {
     handleInputChange(value);
     setIsApiCalled(true);
   };
+
+  useEffect(() => {
+    setIsApiCalled(true);
+  }, [currentDistrict]);
 
   return (
     <div className="relative px-6 overflow-y-auto">
@@ -37,8 +41,8 @@ export default function Sidebar({
       {isApiCalled ? (
         <>
           <h1 className="py-8 text-4xl">
-            {region
-              ? `${region} 근처 주차장이에요.`
+            {currentDistrict
+              ? `${currentDistrict} 근처 주차장이에요.`
               : "주차장 정보를 찾고 있습니다..."}
           </h1>
           <div

--- a/src/constants/icon.ts
+++ b/src/constants/icon.ts
@@ -9,6 +9,9 @@ const ICONS: IconProps = {
   search: "bi bi-search",
   bookmark: "bi bi-bookmark",
   bookmark_fill: "bi bi-bookmark-fill",
+  current_location: "bi bi-crosshair",
+  plus: "bi bi-plus",
+  minus: "bi bi-dash",
 };
 
 export default ICONS;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  kakao: any;
+}

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { SeoulDistrict } from "../interfaces/seoulDistrict";
 import ICONS from "../constants/icon";
+import useGuStore from "../store/gustore";
 
 export default function useMap() {
   const [map, setMap] = useState<any>(null); // 지도 객체를 상태로 관리
@@ -9,7 +9,7 @@ export default function useMap() {
     lng: number;
   } | null>(null);
 
-  const [currentDistrict, setCurrentDistrict] = useState<SeoulDistrict>(""); // 현재 자치구 정보 상태
+  const { setCurrentDistrict } = useGuStore();
 
   const updateDistrict = (center: any) => {
     const geocoder = new window.kakao.maps.services.Geocoder();
@@ -21,23 +21,12 @@ export default function useMap() {
         if (status === window.kakao.maps.services.Status.OK) {
           // 자치구 정보를 찾고 `region_type`이 'H'인 경우 해당 정보를 상태에 저장
           const district = result.find((item: any) => item.region_type === "H");
-          console.log(
-            "result",
-            result,
-            [...district.address_name.split(" ")][1],
-          );
-
           if (district)
-            setCurrentDistrict([...district.address_name.split(" ")][1]);
+            setCurrentDistrict([...district.address_name.split(" ")][1]); // 전역 상태 업데이트
         }
       },
     );
   };
-
-  useEffect(() => {
-    console.log("currentDistrict", currentDistrict);
-  }, [currentDistrict]);
-
   useEffect(() => {
     const loadMap = (lat: number, lng: number) => {
       const container = document.getElementById("map");
@@ -55,6 +44,7 @@ export default function useMap() {
       });
 
       marker.setMap(newMap); // 마커를 지도에 표시
+      updateDistrict(newMap.getCenter());
 
       // 지도 중심 좌표 변경 시 자치구 정보 업데이트
       window.kakao.maps.event.addListener(newMap, "center_changed", () => {

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { SeoulDistrict } from "../interfaces/seoulDistrict";
+import ICONS from "../constants/icon";
+
+export default function useMap() {
+  const [map, setMap] = useState<any>(null); // 지도 객체를 상태로 관리
+  const [currentPosition, setCurrentPosition] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(null);
+
+  const [currentDistrict, setCurrentDistrict] = useState<SeoulDistrict>(""); // 현재 자치구 정보 상태
+
+  const updateDistrict = (center: any) => {
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    geocoder.coord2RegionCode(
+      center.getLng(),
+      center.getLat(),
+      (result: any, status: any) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          // 자치구 정보를 찾고 `region_type`이 'H'인 경우 해당 정보를 상태에 저장
+          const district = result.find((item: any) => item.region_type === "H");
+          console.log(
+            "result",
+            result,
+            [...district.address_name.split(" ")][1],
+          );
+
+          if (district)
+            setCurrentDistrict([...district.address_name.split(" ")][1]);
+        }
+      },
+    );
+  };
+
+  useEffect(() => {
+    console.log("currentDistrict", currentDistrict);
+  }, [currentDistrict]);
+
+  useEffect(() => {
+    const loadMap = (lat: number, lng: number) => {
+      const container = document.getElementById("map");
+      const options = {
+        center: new window.kakao.maps.LatLng(lat, lng), // 사용자의 현재 위치로 중심 좌표 설정
+        level: 3,
+      };
+      const newMap = new window.kakao.maps.Map(container, options);
+      setMap(newMap); // 지도 객체를 상태에 저장
+
+      // 현재 위치에 마커 추가
+      const markerPosition = new window.kakao.maps.LatLng(lat, lng);
+      const marker = new window.kakao.maps.Marker({
+        position: markerPosition,
+      });
+
+      marker.setMap(newMap); // 마커를 지도에 표시
+
+      // 지도 중심 좌표 변경 시 자치구 정보 업데이트
+      window.kakao.maps.event.addListener(newMap, "center_changed", () => {
+        const center = newMap.getCenter();
+        updateDistrict(center); // 중심 좌표 변경 시 자치구 정보 업데이트
+      });
+    };
+
+    // Geolocation API로 현재 위치 가져오기
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          const lat = position.coords.latitude; // 위도
+          const lng = position.coords.longitude; // 경도
+          setCurrentPosition({ lat, lng }); // 현재 위치를 상태에 저장
+          loadMap(lat, lng); // 지도를 현재 위치로 로드
+        },
+        error => {
+          console.error("Geolocation error:", error);
+          // 기본 위치로 지도 로드 (에러 발생 시)
+          loadMap(33.450701, 126.570667);
+        },
+      );
+    } else {
+      // Geolocation을 지원하지 않을 경우 기본 위치로 지도 로드
+      loadMap(33.450701, 126.570667);
+    }
+  }, []);
+
+  // 버튼 클릭 시 현재 위치로 지도의 중심을 이동시키는 함수
+  const moveToCurrentLocation = () => {
+    if (map && currentPosition) {
+      const moveLatLon = new window.kakao.maps.LatLng(
+        currentPosition.lat,
+        currentPosition.lng,
+      );
+      map.setCenter(moveLatLon); // 지도의 중심을 현재 위치로 이동
+    }
+  };
+
+  // 지도 레벨 조절 함수 (줌 인/줌 아웃)
+  const adjustZoomLevel = (delta: number) => {
+    if (map) {
+      let level = map.getLevel(); // 현재 지도의 레벨 가져오기
+      level += delta; // 레벨을 변경 (+1 또는 -1)
+      map.setLevel(level); // 변경된 레벨을 지도에 적용
+    }
+  };
+
+  // 버튼 배열 정의
+  const buttons = [
+    {
+      "aria-label": "Zoom In",
+      className: `${ICONS.plus} bg-white text-black p-4 rounded-full shadow-lg text-4xl`,
+      onClick: () => adjustZoomLevel(-1),
+    },
+    {
+      "aria-label": "Zoom Out",
+      className: `${ICONS.minus} bg-white text-black p-4 rounded-full shadow-lg text-4xl`,
+      onClick: () => adjustZoomLevel(1),
+    },
+    {
+      "aria-label": "현재 위치로 이동",
+      className: `${ICONS.current_location} bg-white text-black p-4 rounded-full shadow-lg text-4xl`,
+      onClick: moveToCurrentLocation,
+    },
+  ];
+  return { buttons };
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,14 +1,30 @@
-import React from "react";
+import React, { useState } from "react";
 import Sidebar from "../../components/main/sidebar";
 import Map from "../../components/main/map";
 
 export default function Main() {
+  const [isMapVisible, setIsMapVisible] = useState(true);
+  const [isApiCalled, setIsApiCalled] = useState(false);
+
+  const handleParkingSelect = () => {
+    if (window.innerWidth < 1024) {
+      setIsMapVisible(true);
+      setIsApiCalled(false);
+    }
+  };
+
   return (
-    <div className="flex flex-row items-center justify-center w-full h-screen text-2xl bg-white">
-      <div className="w-[32%] h-full p-6">
-        <Sidebar />
+    <div className="flex flex-col items-center justify-center w-full h-screen text-2xl bg-white lg:flex-row">
+      <div className="w-full lg:w-[32%] h-screen p-6">
+        <Sidebar
+          onParkingSelect={handleParkingSelect}
+          isApiCalled={isApiCalled}
+          setIsApiCalled={setIsApiCalled}
+        />
       </div>
-      <div className="w-[68%] h-full p-6">
+      <div
+        className={`w-full lg:w-[68%] h-full p-6 ${isMapVisible && !isApiCalled ? "block lg:block" : "hidden lg:block"}`}
+      >
         <Map />
       </div>
     </div>

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -23,7 +23,7 @@ export default function Main() {
         />
       </div>
       <div
-        className={`w-full lg:w-[68%] h-full p-6 ${isMapVisible && !isApiCalled ? "block lg:block" : "hidden lg:block"}`}
+        className={`w-full lg:w-[68%] h-full ${isMapVisible && !isApiCalled ? "block lg:block" : "hidden lg:block"}`}
       >
         <Map />
       </div>

--- a/src/store/gustore.ts
+++ b/src/store/gustore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import { SeoulDistrict } from "../interfaces/seoulDistrict";
+
+interface GuStore {
+  currentDistrict: SeoulDistrict; // 현재 자치구 이름
+  setCurrentDistrict: (district: SeoulDistrict) => void; // 자치구 이름 설정 함수
+}
+
+const useGuStore = create<GuStore>(set => ({
+  currentDistrict: "",
+  setCurrentDistrict: district => set({ currentDistrict: district }),
+}));
+
+export default useGuStore;


### PR DESCRIPTION
**카카오맵api사용**
- geolocation을 이용해 현재 위치에 마커를 표시하도록 하였습니다. (추후 커스텀 예정)
- 줌인,줌아웃,현재위치를 핸들링할 수 있는 버튼을 구현하였습니다.
- 경위도를 통해 현재 위치의 자치구 및 현재 지도의 중심 기준 자치구를 전역변수화하였습니다.
    - 이 과정에서 zustand 사용

**zustand를 이용한 자치구 전역변수화**

- map컴포넌트에서 받아온 자치구 변수를  sidebar컴포넌트에 전달 후 , 해당 자치구 이름을 기반으로 한 주차장 데이터를 다시 list컴포넌트에 전달해야했습니다.
- 이 과정에서 과도한 props 사용이 예상되어 zustand를 사용하여 자치구(seoulDistrict)를 전역변수화하였습니다.

**기능 정리**
 - 위에서 언급한 지도 기본 기능을 구현하였습니다.
 - 초기 로딩 시 현재 위치를 기반으로 받아온 자치구 이름을 통해 sidebar에 주차장 리스트를 보여줍니다.
 - 드래그를 통해 현재 위치를 이동하여, 현재 지도의 자치구가 변하는 경우, sidebar의 주차장 리스트가 새로고침됩니다.
 
![스크린샷 2024-09-30 오후 4 11 22](https://github.com/user-attachments/assets/cd05d985-7751-4cde-a88b-83e45566fdb4)


